### PR TITLE
Fixed config for docker build with new forum

### DIFF
--- a/.docker/web-frontend/nginx.conf
+++ b/.docker/web-frontend/nginx.conf
@@ -9,6 +9,12 @@ events {
   worker_connections  1024;
 }
 
+server {
+	# Copied from https://stackoverflow.com/questions/24415376/post-request-not-allowed-405-not-allowed-nginx-even-with-headers-included
+	# To allow POST on static pages
+    error_page  405     =200 $uri;
+}
+
 http {
   include       /etc/nginx/mime.types;
   default_type  application/octet-stream;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [NEXT]
 ### Updates
-- Update insecure dependencies[#816](https://github.com/geli/issues/816)
-- Updated Frontend to angular6[#716](https://github.com/utetrapp/geli/pull/766)
+- Update insecure dependencies [#816](https://github.com/geli/issues/816)
+- Updated Frontend to angular6 [#716](https://github.com/utetrapp/geli/pull/766)
 - update node version to 10.8.0 [#821](https://github.com/utetrapp/geli/pull/821)
 
 ### Added


### PR DESCRIPTION
fixed the http 405 error

## Description:

Currently the new Forum send data back with a POST. Nginx will refuse this with a 405.

## Improvements
- A workaround for it

## Known Issues:
_NONE_

<!--
ATTENTION:
Remember to prefix your PR-Title with `⚠ WIP: ` if you still work on it.
If you have reached a final state, remove the prefix.
-->
